### PR TITLE
fix: cast JWT_EXPIRY to number in app config

### DIFF
--- a/app/configs/env.config.js
+++ b/app/configs/env.config.js
@@ -13,7 +13,7 @@ const prodExt = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: process.env.JWT_EXPIRY,
+    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,
@@ -55,7 +55,7 @@ const production = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: process.env.JWT_EXPIRY,
+    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,


### PR DESCRIPTION
jwtExpirationInSeconds was reading process.env.JWT_EXPIRY as a raw string, inconsistent with other numeric env vars in this file (port, saltFactor) which already use Number().

Wrapped both prodExt and production config with Number(process.env.JWT_EXPIRY) to make sure consistent type when used for JWT expiry calculations.