### PR TITLE
refactor: Rename jwtExpirationInSeconds to jwtExpiresIn

### DIFF
--- a/app/configs/env.config.js
+++ b/app/configs/env.config.js
@@ -13,7 +13,7 @@ const prodExt = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
+    jwtExpiresIn: process.env.JWT_EXPIRY,
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,
@@ -55,7 +55,7 @@ const production = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
+    jwtExpiresIn: process.env.JWT_EXPIRY,
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -129,7 +129,7 @@ export async function login(req, res) {
 
     // Step 5: Generate JWT token for session management
     const token = Jwt.sign({ user: { id: user.id, username: user.username } }, Config.jwt.jwtSecret, {
-      expiresIn: Config.jwt.jwtExpirationInSeconds,
+      expiresIn: Config.jwt.jwtExpiresIn,
     });
 
     // Store JWT token in user record


### PR DESCRIPTION
Renamed jwtExpirationInSeconds to jwtExpiresIn across prodExt and production config blocks (and any downstream usage).

Old name implied a raw seconds value, but JWT_EXPIRY is set as a string timespan (e.g. "8766h"), which jsonwebtoken's expiresIn param accepts natively. New name matches jsonwebtoken's own expiresIn parameter, making the mapping obvious at a glance.