### PR TITLE
Release: JWT config rename and add gitattributes for line-ending consistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/app/configs/env.config.js
+++ b/app/configs/env.config.js
@@ -13,7 +13,7 @@ const prodExt = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
+    jwtExpiresIn: process.env.JWT_EXPIRY,
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,
@@ -55,7 +55,7 @@ const production = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
+    jwtExpiresIn: process.env.JWT_EXPIRY,
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,

--- a/app/configs/env.config.js
+++ b/app/configs/env.config.js
@@ -13,7 +13,7 @@ const prodExt = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: process.env.JWT_EXPIRY,
+    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,
@@ -55,7 +55,7 @@ const production = {
   },
   jwt: {
     jwtSecret: process.env.JWT_SECRET,
-    jwtExpirationInSeconds: process.env.JWT_EXPIRY,
+    jwtExpirationInSeconds: Number(process.env.JWT_EXPIRY),
   },
   activity: {
     totalConnectLexemeSense: process.env.TOTAL_CONNECT_LEXEME_SENSE,

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -43,7 +43,7 @@ export async function login(req, res) {
 
     // Step 1: Exchange authorization code for access token
     // Construct URL and body for Wikimedia OAuth token endpoint
-    const getAccessTokenUrl = `${Config.wiki.wikimetaUrl}/w/rest.php/oauth2/access_token`;
+    const getAccessTokenUrl = `${Config.wiki.wikidataUrl}/w/rest.php/oauth2/access_token`;
     const getAccessTokenBody = new URLSearchParams({
       grant_type: 'authorization_code',
       code,
@@ -68,7 +68,7 @@ export async function login(req, res) {
     }
 
     // Step 2: Fetch user profile from Wikimedia using obtained access token
-    const getProfileUrl = `${Config.wiki.wikimetaUrl}/w/api.php`;
+    const getProfileUrl = `${Config.wiki.wikidataUrl}/w/api.php`;
     const getProfileQueryParams = {
       action: 'query',
       meta: 'userinfo',

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -68,7 +68,7 @@ export async function login(req, res) {
     }
 
     // Step 2: Fetch user profile from Wikimedia using obtained access token
-    const getProfileUrl = `${Config.wiki.wikidataUrl}/w/api.php`;
+    const getProfileUrl = `${Config.wiki.wikimetaUrl}/w/api.php`;
     const getProfileQueryParams = {
       action: 'query',
       meta: 'userinfo',

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -43,7 +43,7 @@ export async function login(req, res) {
 
     // Step 1: Exchange authorization code for access token
     // Construct URL and body for Wikimedia OAuth token endpoint
-    const getAccessTokenUrl = `${Config.wiki.wikidataUrl}/w/rest.php/oauth2/access_token`;
+    const getAccessTokenUrl = `${Config.wiki.wikimetaUrl}/w/rest.php/oauth2/access_token`;
     const getAccessTokenBody = new URLSearchParams({
       grant_type: 'authorization_code',
       code,

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -60,6 +60,8 @@ export async function login(req, res) {
       },
     });
 
+    console.log('access token response:', JSON.stringify(getAccessTokenResponse));
+
     // Validate token response
     if (getAccessTokenResponse.error) {
       throw Status.ERROR.TOKEN_INVALID;

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -129,7 +129,7 @@ export async function login(req, res) {
 
     // Step 5: Generate JWT token for session management
     const token = Jwt.sign({ user: { id: user.id, username: user.username } }, Config.jwt.jwtSecret, {
-      expiresIn: Config.jwt.jwtExpirationInSeconds,
+      expiresIn: Config.jwt.jwtExpiresIn,
     });
 
     // Store JWT token in user record

--- a/app/controllers/user/v1/AuthController.js
+++ b/app/controllers/user/v1/AuthController.js
@@ -60,8 +60,6 @@ export async function login(req, res) {
       },
     });
 
-    console.log('access token response:', JSON.stringify(getAccessTokenResponse));
-
     // Validate token response
     if (getAccessTokenResponse.error) {
       throw Status.ERROR.TOKEN_INVALID;


### PR DESCRIPTION
## Changes

### 1. JWT config rename (no functional change)
Renamed `jwtExpirationInSeconds` to `jwtExpiresIn` in app config and the auth controller that consumes it. Old name implied seconds, but JWT_EXPIRY is a string timespan (e.g. "8766h"), which jsonwebtoken's expiresIn accepts natively. New name matches jsonwebtoken's own expiresIn param for clarity.

Files: config.js, auth controller

### 2. Add .gitattributes
Enforce LF for text files, prevent future CRLF/UTF-16 encoding issues.

## Notes
No env var or .env changes required, JWT_EXPIRY format unchanged.